### PR TITLE
CLIP-2715 version bump required packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
   "require": {
     "php": ">=7.1",
     "doctrine/annotations": "^1.6",
-    "symfony/dependency-injection": "^5.1",
-    "symfony/http-kernel": "^5.1",
-    "vcn/symfony-autofactory": "^0.2.0"
+    "symfony/dependency-injection": "^5.1 || ^6.4",
+    "symfony/http-kernel": "^5.1 || ^6.4",
+    "vcn/symfony-autofactory": "^0.3.0"
   }
 }


### PR DESCRIPTION
**Gerelateerde PRs**

https://github.com/vcn/symfony-autofactory/pull/3

**Deployment**
minor tag

**Wat heb ik gedaan**
de symfony http-kernel, dependency-injection & autofactory requirements geupdate, zodat deze ook compatible zijn met symfony 6.1. Dit is intern getest D.M.V. lokale forks gedurende een microservice upgrade.